### PR TITLE
Suppress FP for opentelemetry-grpc-1.6

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -23,4 +23,11 @@
         <cve>CVE-2022-3509</cve>
         <cve>CVE-2022-3510</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: opentelemetry-grpc-1.6-1.23.0-alpha.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.instrumentation/opentelemetry\-grpc\-1\.6@.*$</packageUrl>
+        <cve>CVE-2020-7768</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
`opentelemetry-grpc-1.6-1.23.0-alpha` is being identified as a grpc:grpc dependency due to `cpe:2.3:a:grpc:grpc:*:*:*:*:*:-:*:*`