### PR TITLE
Suppress CVE-2023-35116 for jackson-databind

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -78,4 +78,11 @@
         <cve>CVE-2022-31678</cve>
         <cve>CVE-2022-31701</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: jackson-databind-*.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/com.fasterxml.jackson.core/jackson-databind@.*$</packageUrl>
+        <cve>CVE-2023-35116</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Disputed CVE that marks all versions as vulnerable - https://github.com/FasterXML/jackson-databind/issues/3972