### PR TITLE
Suppress CVE-2023-2976 for shaded dependency

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -78,4 +78,11 @@
         <cve>CVE-2022-31678</cve>
         <cve>CVE-2022-31701</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: protoc-gen-grpc-kotlin-1.3.0-jdk8.jar (shaded: com.google.guava:guava:31.0.1-android)
+   ]]></notes>
+        <filePath regex="true">.*\/protoc-gen-grpc-kotlin-1.3.0-jdk8.jar\/.*\/com.google.guava/guava/pom.xml</filePath>
+        <cve>CVE-2023-2976</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
Shaded dependency com.google.guava:guava of protoc-gen-grpc-kotlin-1.3.0-jdk8 is impacted by the vulnerability