### PR TITLE
Suppress CVE-2023-36665 for `protobufjs`

### DIFF
--- a/dependency-suppression/cve-suppressed-tools.xml
+++ b/dependency-suppression/cve-suppressed-tools.xml
@@ -6,6 +6,7 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:npm/protobufjs@.*$</packageUrl>
         <vulnerabilityName>CVE-2022-25878</vulnerabilityName>
+        <vulnerabilityName>CVE-2023-36665</vulnerabilityName>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
`protobufjs` upto version `7.2.3` is affected by [prototype pollution vulnerability](https://vuldb.com/?id.232996).
It's been used as peer-dependency for following packages

- `ts-proto` uses `protobufjs: 6.11.3`
- `@google-cloud/retail` uses `protobufjs: 7.2.3`



