### PR TITLE
Suppress FPs for CVE-2023-33953

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -29,7 +29,7 @@
         <notes><![CDATA[
    file name: grpc-kotlin-stub-1.3.0.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-kotlin\-stub@.*$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-kotlin\-stub@1.3.0$</packageUrl>
         <cve>CVE-2023-33953</cve>
     </suppress>
     <suppress>

--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -14,6 +14,7 @@
    ]]></notes>
         <filePath regex="true">.*\/protoc-gen-grpc-kotlin-1\.3\.0-jdk8\.jar</filePath>
         <cve>CVE-2020-7768</cve>
+        <cve>CVE-2023-33953</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -26,10 +27,18 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
+   file name: grpc-kotlin-stub-1.3.0.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-kotlin\-stub@.*$</packageUrl>
+        <cve>CVE-2023-33953</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
    file name: opentelemetry-grpc-1.6-1.23.0-alpha.jar
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.instrumentation/opentelemetry\-grpc\-1\.6@.*$</packageUrl>
         <cve>CVE-2020-7768</cve>
+        <cve>CVE-2023-33953</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
- `opentelemetry-grpc-1.6-1.23.0-alpha`:
does not apply

- `protoc-gen-grpc-kotlin-1.3.0-jdk8 & grpc-kotlin-stub-1.3.0.jar` : 
the CVE affects transitive libraries of these artifacts which have already been bumped. There are also no new versions for them available.