### PR TITLE
Suppress FP for CVE-2023-4785

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -39,6 +39,7 @@
         <packageUrl regex="true">^pkg:maven/io\.opentelemetry\.instrumentation/opentelemetry\-grpc\-1\.6@.*$</packageUrl>
         <cve>CVE-2020-7768</cve>
         <cve>CVE-2023-33953</cve>
+        <cve>CVE-2023-4785</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
The CVE is meant for `grpc:grpc` artifacts