### PR TITLE
Suppress FP CVE-2023-37475 for avro-protobuf

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -103,4 +103,11 @@
         <packageUrl regex="true">^pkg:maven/org\.quartz\-scheduler/quartz@.*$</packageUrl>
         <cve>CVE-2023-39017</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: avro-protobuf-1.11.2.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven\/org\.apache\.avro\/avro\-protobuf@.*$</packageUrl>
+        <cve>CVE-2023-37475</cve>
+    </suppress>
 </suppressions>

--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -105,7 +105,7 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-   file name: avro-protobuf-1.11.2.jar
+   file name: avro-protobuf-*.jar
    ]]></notes>
         <packageUrl regex="true">^pkg:maven\/org\.apache\.avro\/avro\-protobuf@.*$</packageUrl>
         <cve>CVE-2023-37475</cve>


### PR DESCRIPTION
CVE is meant for a go library of avro project