### PR TITLE
feat: suppressed dset and added separate file for tools fe

### DIFF
--- a/dependency-suppression/cve-suppressed-tools-frontend.xml
+++ b/dependency-suppression/cve-suppressed-tools-frontend.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress>
+        <notes><![CDATA[
+        file name: async-validator:1.11.5
+        ]]></notes>
+        <packageUrl regex="true">^pkg:npm/async\-validator@.*$</packageUrl>
+        <vulnerabilityName>CVE-2021-3887</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: dset:3.1.2
+        ]]></notes>
+        <packageUrl regex="true">^pkg:npm/dset@.*$</packageUrl>
+        <cve>CVE-2022-25645</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: opener:1.5.2
+        ]]></notes>
+        <packageUrl regex="true">^pkg:npm/opener@.*$</packageUrl>
+        <cpe>cpe:/a:opener_project:opener</cpe>
+    </suppress>
+</suppressions>

--- a/dependency-suppression/cve-suppressed-tools.xml
+++ b/dependency-suppression/cve-suppressed-tools.xml
@@ -14,4 +14,11 @@
         <packageUrl regex="true">^pkg:npm/word\-wrap@.*$</packageUrl>
         <vulnerabilityName>CVE-2023-26115</vulnerabilityName>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+        file name: dset:3.1.2
+        ]]></notes>
+        <packageUrl regex="true">^pkg:npm/dset@.*$</packageUrl>
+        <cpe>cpe:/a:dset_project:dset</cpe>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
The dependency check in the [build](https://github.com/din-global/customer-management-portal-service/actions/runs/6492557618/job/17631722148?pr=123) is failing because the latest version of nest is using a vulnerable dependency [dset](https://github.com/advisories/GHSA-23wx-cgxq-vpwx) which is used to prevent proto-type pollution. Since protos are no longer maintained at our end so we can omit this package.
A separate file is added for tools frontend which contains all three vulnerable packages common in all fe's. Since those packages are not being used so they can be omitted.