### PR TITLE
Suppress FP CVE-2023-43810 for opentelemetry proto

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -44,7 +44,7 @@
     <suppress>
         <notes><![CDATA[
    file name: opentelemetry-proto-0.19.0-alpha.jar
-   FP as the CVE is for open telemetry-python
+   FP as the CVE is for opentelemetry-python
    ]]></notes>
         <packageUrl regex="true">^pkg:maven\/io\.opentelemetry\.proto\/opentelemetry\-proto@0\.19\.0-alpha$</packageUrl>
         <cve>CVE-2023-43810</cve>

--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -44,6 +44,7 @@
     <suppress>
         <notes><![CDATA[
    file name: opentelemetry-proto-0.19.0-alpha.jar
+   FP as the CVE is for open telemetry-python
    ]]></notes>
         <packageUrl regex="true">^pkg:maven\/io\.opentelemetry\.proto\/opentelemetry\-proto@0\.19\.0-alpha$</packageUrl>
         <cve>CVE-2023-43810</cve>

--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -43,6 +43,13 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
+   file name: opentelemetry-proto-0.19.0-alpha.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven\/io\.opentelemetry\.proto\/opentelemetry\-proto@0\.19\.0-alpha$</packageUrl>
+        <cve>CVE-2023-43810</cve>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[
    file name: pulsar-client-all-*.jar (shaded: org.apache.avro:avro-protobuf:1.10.2)
    file name: pulsar-client-all-*.jar (shaded: org.apache.avro:avro:1.10.2)
    ]]></notes>


### PR DESCRIPTION
the CVE description only mentions opentelemetry-python as a reference, and the version mentioned is related to that

I don't see any relevant issues in opentelemetry-java, and besides, the vulnerable dependency for which our build is showing the CVE is opentelemetry-proto, which is not linked to the CVE