### PR TITLE
Handle FPs for CVE-2023-44487

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -15,6 +15,7 @@
         <filePath regex="true">.*\/protoc-gen-grpc-kotlin-1\.3\.0-jdk8\.jar</filePath>
         <cve>CVE-2020-7768</cve>
         <cve>CVE-2023-33953</cve>
+        <cve>CVE-2023-44487</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -31,6 +32,7 @@
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-kotlin\-stub@1.3.0$</packageUrl>
         <cve>CVE-2023-33953</cve>
+        <cve>CVE-2023-44487</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
@@ -40,6 +42,7 @@
         <cve>CVE-2020-7768</cve>
         <cve>CVE-2023-33953</cve>
         <cve>CVE-2023-4785</cve>
+        <cve>CVE-2023-44487</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[


### PR DESCRIPTION
- grpc-kotlin-stub-1.3.0.jar: FP as matched CPE is for grpc go

- opentelemetry-grpc-1.6-1.23.0-alpha.jar: FP as matched CPE is for grpc go

- protoc-gen-grpc-kotlin-1.3.0-jdk8.jar: FP as matched CPE is for grpc go