### PR TITLE
Chore: Supress False Positive for CVE-2023-44487

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -122,4 +122,12 @@
         <packageUrl regex="true">^pkg:maven\/io\.netty\/netty\-.*@.*$</packageUrl>
         <cve>CVE-2023-4586</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+    file name: grpc-*-1.58.*
+    FP for grpc-go
+    ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.grpc/grpc\-.*@1\.58\.*$</packageUrl>
+        <cve>CVE-2023-44487</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
We bumped `net.devh:grpc-server-spring-boot-starte`r and `net.devh:grpc-client-spring-boot-starter` versions to 2.15.0.RELEASE. This brings in numerous grpc artifacts whose CPE is being matched to CPE for grpc-go. This is a False positive, and consequently the CVE for all relevant artifacts was suppressed.