### PR TITLE
Chore: Suppress CVE-2021-3765 & CVE-2020-36448

### DIFF
--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -99,9 +99,9 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-   file name: commons-validator-1.8.0-sources.jar
+   file name: commons-validator-*-sources.jar
    ]]></notes>
-        <packageUrl regex="true">^pkg:maven/commons\-validator/commons\-validator@1.8.0$</packageUrl>
+        <packageUrl regex="true">^pkg:maven/commons\-validator/commons\-validator@.*</packageUrl>
         <cve>CVE-2021-3765</cve>
     </suppress>
 </suppressions>

--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -101,7 +101,7 @@
     <suppress>
         <notes><![CDATA[
    file name: commons-validator-*-sources.jar
-   Remove the following suppression once https://github.com/jeremylong/DependencyCheck/issues/6682 is resolved
+   Remove the suppression once https://github.com/jeremylong/DependencyCheck/issues/6682 is resolved
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/commons\-validator/commons\-validator@.*</packageUrl>
         <cve>CVE-2021-3765</cve>
@@ -109,7 +109,7 @@
     <suppress>
         <notes><![CDATA[
    file name: spring-boot-starter-cache-*-sources.jar
-   Remove the following suppression once https://github.com/jeremylong/DependencyCheck/issues/6682 is resolved
+   Remove the suppression once https://github.com/jeremylong/DependencyCheck/issues/6682 is resolved
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-starter\-cache@.*$</packageUrl>
         <cve>CVE-2020-36448</cve>

--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -93,6 +93,7 @@
     <suppress>
         <notes><![CDATA[
    file name: global.din.*-utilities-*.jar
+   Remove the suppression once https://github.com/jeremylong/DependencyCheck/issues/6682 is resolved
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/global\.din/.*\-utilities@.*$</packageUrl>
         <cve>CVE-2023-26105</cve>
@@ -100,6 +101,7 @@
     <suppress>
         <notes><![CDATA[
    file name: commons-validator-*-sources.jar
+   Remove the following suppression once https://github.com/jeremylong/DependencyCheck/issues/6682 is resolved
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/commons\-validator/commons\-validator@.*</packageUrl>
         <cve>CVE-2021-3765</cve>
@@ -107,6 +109,7 @@
     <suppress>
         <notes><![CDATA[
    file name: spring-boot-starter-cache-*-sources.jar
+   Remove the following suppression once https://github.com/jeremylong/DependencyCheck/issues/6682 is resolved
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-starter\-cache@.*$</packageUrl>
         <cve>CVE-2020-36448</cve>

--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -104,4 +104,11 @@
         <packageUrl regex="true">^pkg:maven/commons\-validator/commons\-validator@.*</packageUrl>
         <cve>CVE-2021-3765</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: spring-boot-starter-cache-*-sources.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.springframework\.boot/spring\-boot\-starter\-cache@.*$</packageUrl>
+        <cve>CVE-2020-36448</cve>
+    </suppress>
 </suppressions>

--- a/dependency-suppression/cve-suppressed.xml
+++ b/dependency-suppression/cve-suppressed.xml
@@ -97,4 +97,11 @@
         <packageUrl regex="true">^pkg:maven/global\.din/.*\-utilities@.*$</packageUrl>
         <cve>CVE-2023-26105</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+   file name: commons-validator-1.8.0-sources.jar
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/commons\-validator/commons\-validator@1.8.0$</packageUrl>
+        <cve>CVE-2021-3765</cve>
+    </suppress>
 </suppressions>


### PR DESCRIPTION
With Kotlin 2.0.0, dependencyCheck is scanning both JARs and source JARs (which contain Java files for debugging). This unintended behavior leads to source JARs being flagged as vulnerable. This issue is currently open in the DependencyCheck repository [here](https://github.com/jeremylong/DependencyCheck/issues/6682). Until a fix is merged, we will need to suppress these vulnerabilities manually.